### PR TITLE
Relax aiohttp version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp~=3.7.4
+aiohttp~=3.7
 asynctest~=0.13.0
 codecov~=2.1.10
 certifi


### PR DESCRIPTION
Noticed version conflicts in Home Assistant, caused by this package:

```txt
The conflict is caused by:
    pytest-aiohttp 0.3.0 depends on aiohttp>=2.3.5
    accuweather 0.3.0 depends on aiohttp
    adax 0.1.1 depends on aiohttp>=3.0.6
    adguardhome 0.5.0 depends on aiohttp>=3.0.0
    advantage-air 0.2.5 depends on aiohttp
    aio-geojson-geonetnz-quakes 0.13 depends on aiohttp<4 and >=3.7.4
    aio-geojson-geonetnz-volcano 0.6 depends on aiohttp<4 and >=3.7.4
    aio-geojson-nsw-rfs-incidents 0.4 depends on aiohttp<4 and >=3.7.4
    aioambient 2021.10.1 depends on aiohttp<4.0.0 and >=3.7.4
    aioazuredevops 1.3.5 depends on aiohttp>=3.6.2
    aiobotocore 1.2.2 depends on aiohttp>=3.3.1
    aioeafm 0.1.2 depends on aiohttp<4.0.0 and >=3.6.1
    aioeagle 1.1.0 depends on aiohttp
    aioemonitor 1.0.5 depends on aiohttp>=3.7.0
    aioflo 0.4.1 depends on aiohttp<4.0.0 and >=3.6.2
    aioguardian 2021.11.0 depends on aiohttp<4.0.0 and >=3.7.4post0
    aioharmony 0.2.8 depends on aiohttp
    aiohttp-cors 0.7.0 depends on aiohttp>=1.1
    aiohue 2.6.3 depends on aiohttp
    aiolookin 0.0.3 depends on aiohttp>=3.7.4
    aiolyric 1.0.8 depends on aiohttp>=3.7.3
    aiomodernforms 0.1.8 depends on aiohttp>=3.0.0
    aiomusiccast 0.13.1 depends on aiohttp<4.0.0 and >=3.7.4
    aionanoleaf 0.0.3 depends on aiohttp
    aionotion 3.0.2 depends on aiohttp<4.0.0 and >=3.7.4
    aiopvapi 1.6.14 depends on aiohttp<4 and >=3
    aiopvpc 2.2.1 depends on aiohttp>=3.7.4.post0
    aiorecollect 1.0.8 depends on aiohttp<4.0.0 and >=3.7.4
    aioridwell 0.2.0 depends on aiohttp<4.0.0 and >=3.7.4
    aioshelly 1.0.4 depends on aiohttp
    aiosyncthing 0.5.1 depends on aiohttp>=3.7.4
    aiotractive 0.5.2 depends on aiohttp>=3.7.4
    aiounifi 28 depends on aiohttp
    aiowatttime 0.1.1 depends on aiohttp<4.0.0 and >=3.7.4
    aioymaps 1.2.1 depends on aiohttp>=3.0.0
    airly 1.1.0 depends on aiohttp>=3.5.4
    airthings-cloud 0.0.1 depends on aiohttp
    ambee 0.4.0 depends on aiohttp>=3.0.0
    ambiclimate 0.2.1 depends on aiohttp>=3.0.6
    async-upnp-client 0.22.12 depends on aiohttp>=3.7.4
    blebox-uniapi 1.3.3 depends on aiohttp>=3
    bond-api 0.1.14 depends on aiohttp>=3.6.1
    bsblan 0.4.0 depends on aiohttp>=3.0.0
    coronavirus 1.1.1 depends on aiohttp>=3.0.0
    crownstone-cloud 1.4.8 depends on aiohttp~=3.7.4
    The user requested (constraint) aiohttp==3.8.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

This PR relaxed the version requirement for `aiohttp` to allow all major versions of the 3.x range.

Will create an issue for other issues with this package.